### PR TITLE
fix: should fix the geolocation ip

### DIFF
--- a/src/app/api/proxy/route.ts
+++ b/src/app/api/proxy/route.ts
@@ -4,7 +4,7 @@ import { NextRequest, NextResponse } from "next/server";
 export const GET = async (req: NextRequest) => {
     try {
         //extract the ip
-        const ip = req.headers.get("x-forwarded-for") || req.headers.get("x-real-ip") || req.ip;
+        const ip = (req.headers.get("x-forwarded-for") || req.headers.get("x-real-ip") || req.ip || "").split(",")[0].trim();
         if(!ip) {
             return NextResponse.json(
                 { error: "Unable to determine IP address: " + ip },


### PR DESCRIPTION
from production the ip that sending is = "1.46.X.X, 162.XXX.X.X"
but we want only "1.46.X.X" select only the first ip should fix the problem

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Enhanced IP address extraction logic for better accuracy when handling `x-forwarded-for` headers.
  - Improved error reporting for scenarios where the IP address cannot be determined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->